### PR TITLE
Enable highlighting for quickfix line & fix search

### DIFF
--- a/lua/modus-themes/highlights.lua
+++ b/lua/modus-themes/highlights.lua
@@ -67,7 +67,7 @@ function M.core_highlights(colors)
 	-- syntax['MoreMsg'] = {}
 	-- syntax['NormalFloat'] = {}
 	-- syntax['Question'] = {}
-	-- syntax['QuickFixLine'] = {}
+	syntax['QuickFixLine'] = {fg=colors.fg_main, bg=colors.bg_main}
 	-- syntax['SpecialKey'] = {}
 	syntax['Menu'] = syntax['Pmenu']
 	syntax['Scrollbar'] = syntax['PmenuSbar']


### PR DESCRIPTION
Hi @ishan9299, thank you for your work on this excellent port of modus themes.

While using this theme I noticed that the QuickFixLine syntax hadn't been enabled, specifically when doing a project wide search, the highlighting seemed a bit off. Notice the before/after screenshots below:

Before:
![image](https://user-images.githubusercontent.com/3199183/153521867-4b9050e8-db0a-414d-8412-a664e567295c.png)

After (this change):
![image](https://user-images.githubusercontent.com/3199183/153521918-3aaddff0-95ec-4f81-acf6-a36a33c83b1a.png)

I thought I'd open a PR for this (although it's a pretty minor change :) )