### PR TITLE
Fix highlight for DiagnosticHint

### DIFF
--- a/lua/modus-themes/highlights.lua
+++ b/lua/modus-themes/highlights.lua
@@ -199,6 +199,7 @@ function M.core_highlights(colors)
 
 	-- Specific green for Diagnostichint
 	syntax['diagnostichint'] = {fg=colors.green_alt}
+	syntax['diagnosticinfo'] = {fg=colors.blue_alt}
 
 	-- nix
 	syntax['nixattributedefinition'] = {fg=colors.cyan}
@@ -259,7 +260,7 @@ function M.core_highlights(colors)
 	syntax['tsconstructor'] = syntax['Type']
 	syntax['tskeywordfunction'] = syntax['Type']
 	syntax['tsparameter'] = syntax['Label']
-  syntax['luaTSVariable'] = {fg=colors.fg_main}
+    syntax['luaTSVariable'] = {fg=colors.fg_main}
 	-- syntax['tsvariable'] = syntax['Identifier']
 	syntax['tsvariablebuiltin'] = syntax['Conditional']
 	syntax['tstag'] = syntax['Label']

--- a/lua/modus-themes/highlights.lua
+++ b/lua/modus-themes/highlights.lua
@@ -200,6 +200,7 @@ function M.core_highlights(colors)
 	-- Specific green for Diagnostichint
 	syntax['diagnostichint'] = {fg=colors.green_alt}
 	syntax['diagnosticinfo'] = {fg=colors.blue_alt}
+	syntax['diagnosticwarn'] = {fg=colors.yellow_alt}
 
 	-- nix
 	syntax['nixattributedefinition'] = {fg=colors.cyan}

--- a/lua/modus-themes/highlights.lua
+++ b/lua/modus-themes/highlights.lua
@@ -197,6 +197,9 @@ function M.core_highlights(colors)
 	syntax['markdownrule'] = {fg=colors.fg_special_warm, style='bold'}
 	syntax['markdownurl'] = {fg=colors.blue_faint}
 
+	-- Specific green for Diagnostichint
+	syntax['diagnostichint'] = {fg=colors.green_alt}
+
 	-- nix
 	syntax['nixattributedefinition'] = {fg=colors.cyan}
 	syntax['nixattribute'] = {fg=colors.blue_alt_other}


### PR DESCRIPTION
Hi @ishan9299, another PR for you.

When a Diagnostic hint popup shows up in `modus-operandi` the highlighted color is "Light Grey" which is effectively useless with the light theme (looks okay in `modus-vivendi` though).

Check before/after for clear example:

modus-operandi before this change:
![image](https://user-images.githubusercontent.com/3199183/153644442-da4fac5d-78e6-4d92-96c8-4c8f18be59f9.png)

modus-operandi after this change:
![image](https://user-images.githubusercontent.com/3199183/153644525-6f2ff7e1-bec4-4c85-a9bf-177c69517517.png)

modus-vivendi before this change:
![image](https://user-images.githubusercontent.com/3199183/153644855-58dfd15d-fb4f-4176-b56f-a83edf3f9d9a.png)

modus-vivendi after this change:
![image](https://user-images.githubusercontent.com/3199183/153644672-62e226a6-6e85-4972-a6bd-b4b4f478bf0d.png)

Admittedly it's arguable whether the Diagnostic hint should be green but it at least is consistent and more importantly _visible_ properly in both the themes.