### PR TITLE
Set g:colors_name for both themes.

### DIFF
--- a/colors/modus-operandi.lua
+++ b/colors/modus-operandi.lua
@@ -198,6 +198,7 @@ local colors = {
 local modus_themes = require('modus-themes.highlights')
 modus_themes.core_highlights(colors)
 modus_themes.set_terminal(colors)
+vim.g.colors_name = 'modus-operandi'
 
 if vim.g.modus_moody_enable == 1 then
 	require('modus-themes.galaxyline').set_statusline(colors)

--- a/colors/modus-vivendi.lua
+++ b/colors/modus-vivendi.lua
@@ -214,6 +214,7 @@ local colors = {
 local modus_themes = require('modus-themes.highlights')
 modus_themes.core_highlights(colors)
 modus_themes.set_terminal(colors)
+vim.g.colors_name = 'modus-vivendi'
 
 if vim.g.modus_moody_enable == 1 then
 	require('modus-themes.galaxyline').set_statusline(colors)


### PR DESCRIPTION
See `:help g:colors_name`.
No functional benefit, but means the correct colorscheme names are shown when `:colorscheme` is run without an argument.